### PR TITLE
Fix get-observations

### DIFF
--- a/R/get_observations.R
+++ b/R/get_observations.R
@@ -22,7 +22,7 @@ get_observations <- function(dir, target_date = Sys.Date(),
     .(region = as.character(location_name),
       date = as.Date(date), primary, secondary)
   ]
-  obs <- obs[date >= (max(date) - weeks * 7)]
+  obs <- obs[date >= (max(target_date) - weeks * 7)]
   obs <- obs[date <= target_date]
   obs <- obs[primary < 0, primary := 0]
   obs <- obs[secondary < 0, secondary := 0]


### PR DESCRIPTION
Not 100% sure this is right, but I think it should filter for the target_date, not the actual date. 
Otherwise there is no way to run this for past target_dates, as the data that is left in is determined by the most recent available date, not the target_date. 

This PR therefore changes 'date' to 'target_date' when filtering observations