### PR TITLE
correct get_observations()

### DIFF
--- a/R/get_observations.R
+++ b/R/get_observations.R
@@ -23,7 +23,7 @@ get_observations <- function(dir, target_date = Sys.Date(),
     .(region = as.character(location_name),
       date = as.Date(date), primary, secondary)
   ]
-  obs <- obs[date >= (max(target_date) - weeks * 7)]
+  obs <- obs[date >= (as.Date(target_date) - weeks * 7)]
   obs <- obs[date <= target_date]
   obs <- obs[primary < 0, primary := 0]
   obs <- obs[secondary < 0, secondary := 0]


### PR DESCRIPTION
sometimes you find a bug, sometimes you introduce a bug... 
Should have tested that more carefully. Previous version relied on `target_date` as if it were a column of the data.table, which it isn't. Fixed now, sorry!